### PR TITLE
Use protocol relative link to d3

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,7 +68,7 @@ to where you clicked. The pink border tells you the current node being searched 
 	<button class="button pause-button"></button>
 	<button class="button step-over-button"></button>
 </div>
-<script src="http://d3js.org/d3.v3.min.js"></script>
+<script src="//cdnjs.cloudflare.com/ajax/libs/d3/3.5.6/d3.min.js"></script>
 <script>
 
 var width = 500,


### PR DESCRIPTION
I use the HTTPS everywhere plugin which redirects me to an https version of your github pages site, but the problem is that trying to include d3 from the d3 site over http causes it to be blocked because of mixed-content. This fixes that problem.
